### PR TITLE
adding support for Seurat 4, allow exporting multiple matrices, stop …

### DIFF
--- a/R/cellbrowser.R
+++ b/R/cellbrowser.R
@@ -1,10 +1,6 @@
 # Build a UCSC cell browser website from a \code{Seurat} object
 #
 NULL
-#require(reticulate)
-#require(Matrix)
-#require(R.utils)
-
 #' Used by \code{ExportToCellbrowser}:
 #' Write a big sparse matrix to a .tsv.gz file by writing chunks, concating them with the Unix cat command,
 #' then gziping the result. This does not work on Windows, we'd have to use the copy /b command there.
@@ -22,33 +18,33 @@ NULL
 #' writeSparseTsvChunks( pbmc_small@data, "exprMatrix.tsv.gz")
 #' }
 #'
-writeSparseTsvChunks = function (inMat, outFname, sliceSize=1000) {
-    fnames = c()
+writeSparseTsvChunks = function (inMat, outFname, sliceSize=1000) { 
+    fnames = c() 
     setDTthreads(threads = 8)  # otherwise this would use dozens of CPUs on a fat server
-    mat = inMat
+    mat = inMat 
     geneCount = nrow(mat)
     message("Writing expression matrix to ", outFname)
     startIdx = 1
-    while (startIdx < geneCount) {
-        endIdx <- min(startIdx+sliceSize-1, geneCount)
-        matSlice <- mat[startIdx:endIdx,]
+    while (startIdx < geneCount) { 
+        endIdx <- min(startIdx+sliceSize-1, geneCount) 
+        matSlice <- mat[startIdx:endIdx,] 
         denseSlice <- as.matrix(x = matSlice)
-        dt <- data.table(denseSlice)
-        dt <- cbind(gene = rownames(x = matSlice), dt)
-        writeHeader <- startIdx == 1
+        dt <- data.table(denseSlice) 
+        dt <- cbind(gene = rownames(x = matSlice), dt) 
+        writeHeader <- startIdx == 1 
         sliceFname <- paste0("temp", startIdx,".txt")
         fwrite(dt, sep="\t", file=sliceFname, quote = FALSE, col.names = writeHeader)
         fnames <- append(x = fnames, values = sliceFname);
         startIdx <- startIdx + sliceSize
-    }
+    } 
     message("Concatenating chunks")
     system(command = paste(
-       "cat",
+       "cat", 
        paste(fnames, collapse=" "),
        "| gzip >",
        outFname,
        sep = " "
-    ))
+    )) 
     unlink(x = fnames)
     return(invisible(x = NULL))
 }
@@ -57,18 +53,71 @@ writeSparseTsvChunks = function (inMat, outFname, sliceSize=1000) {
 #' Return a matrix object from a Seurat object or show an error message
 #'
 #' @param object Seurat object
-#' @param matrix.slot the name of the slot
+#' @param slotNames vector with the names of the slots to export
+#' @return a list with filename prefix -> matrix object. prefix usually is "scale_data" or "counts"
 #'
-findMatrix = function(object, matrix.slot ) {
-  if (matrix.slot == "counts") {
-    counts <- GetAssayData(object = object, slot = "counts")
-  } else if (matrix.slot == "scale.data") {
-    counts <- GetAssayData(object = object, slot="scale.data")
+findMatrices = function(object, slotNames ) {
+  slotMatrices = list()
+  slots <- list()
+  for (slotName in slotNames) {
+      mat <- GetAssayData(object = object, slot = slotName)
+      if (slotName == "scale.data")
+          slotName <- "scale" #  dots in filenames are not good
+      # do not use any prefixes if we export just a single matrix (stay compatible with old code)
+      if (length(slotNames)==1)
+          slotName <- ""
+      slotMatrices [[slotName]] <- mat
   }
-  else if (matrix.slot=="data") {
-    counts <- GetAssayData(object = object)
+  return(slotMatrices)
+}
+
+#' used by ExportToCellbrowser:
+#' Write a matrix to a file, as either as .tsv.gz or .mtx.gz+barcodes+genes
+#' Filename is exprMatrix<suffix>.tsv.gz
+#'
+#' @param counts The matrix, usually a sparse matrix
+#' @param prefix Added to the base filename, can be "" or "norm_" or something similar
+#' @param use.mtx If true, will write to <prefix>matrix.mtx and <prefix>features/barcodes.tsv
+#'
+saveMatrix <- function(counts, dir, prefix, use.mtx) {
+  # Export expression matrix
+  message("Writing matrix with prefix ",prefix," to directory ",dir, "(use.mtx is ", use.mtx, ")")
+  too.big = ((((ncol(counts)/1000)*(nrow(counts)/1000))>2000) && is(counts, 'sparseMatrix'))
+  if (prefix!="" && !endsWith(prefix, "_"))
+      prefix <- paste0(prefix, "_")
+
+  if (use.mtx || too.big) {
+        # we have to write the matrix to an mtx file
+        matrixPath <- file.path(dir, paste(prefix, "matrix.mtx", sep=""))
+        genesPath <- file.path(dir, paste(prefix, "features.tsv", sep=""))
+        barcodesPath <- file.path(dir, paste(prefix, "barcodes.tsv", sep=""))
+        message("Writing expression matrix to ", matrixPath)
+        writeMM(counts, matrixPath)
+        # easier to load if the genes file has at least two columns. Even though seurat objects
+        # don't have yet explicit geneIds/geneSyms data, we just duplicate whatever the matrix has now
+        write.table(as.data.frame(cbind(rownames(counts), rownames(counts))), file=genesPath, sep="\t", row.names=F, col.names=F, quote=F)
+        write(colnames(counts), file = barcodesPath)
+        message("Gzipping expression matrix")
+        gzip(matrixPath)
+        gzip(genesPath)
+        gzip(barcodesPath)
   } else {
-    stop("matrix.slot can only be one of: counts, scale.data, data")
+      # we can write the matrix as a tsv file
+      gzPath <- file.path(dir, paste(prefix, "exprMatrix.tsv.gz", sep=""))
+      if (too.big) {
+          if (.Platform$OS.type=="windows")
+              error("Cannot write very big matrices to a text file on Windows. Please use the --useMtx (R: use.mtx) option")
+          writeSparseTsvChunks(counts, gzPath);
+      } else {
+          mat = as.matrix(counts)
+          genes <- rownames(counts)
+          df <- as.data.frame(mat, check.names=FALSE)
+          df <- data.frame(gene=genes, df, check.names = FALSE)
+          z <- gzfile(gzPath, "w")
+          message("Writing expression matrix to ", gzPath)
+          write.table(x = df, sep="\t", file=z, quote = FALSE, row.names = FALSE)
+          close(con = z)
+      }
   }
 }
 
@@ -86,7 +135,9 @@ findMatrix = function(object, matrix.slot ) {
 #' object or via this argument, they are recalculated with \code{FindAllMarkers}
 #' @param markers.n if no markers were supplied, FindAllMarkers is run.
 #' This parameter indicates how many markers to calculate, default is 100
-#' @param matrix.slot matrix to use, default is 'counts'
+#' @param matrix.slot matrix to export, default is 'counts'. Can also be a comma-separated
+#'        list, e.g. 'counts,scale.data', in which case the output filenames have 
+#'        a prefix to distinguish them.
 #' @param use.mtx export the matrix in .mtx.gz format. Default is False,
 #'        unless the matrix is bigger than R's maximum matrix size.
 #' @param cluster.field name of the metadata field containing cell cluster
@@ -158,72 +209,36 @@ ExportToCellbrowser <- function(
   skip.reductions = FALSE
 ) {
   if (!requireNamespace("Seurat", quietly = TRUE)) {
-    stop("This script requires that Seurat (V2 or V3) is installed")
+    stop("This script requires that Seurat (V2 or higher) is installed")
   }
 
-  message("Seurat Version installed: ", packageVersion("Seurat"))
-  message("Object was created with Seurat version ", object@version)
+  # various seurat-version related business
+  message("SeuratVersion installed = ", packageVersion("Seurat"))
+  message("ObjectVersion Seurat object was created with Seurat version = ", object@version)
 
-  objMaj = package_version(object@version)$major
-  pkgMaj = package_version(packageVersion("Seurat"))$major
-
-  if (objMaj!=2 && objMaj!=3) {
-          stop("can only process Seurat2 or Seurat3 objects, object was made with Seurat ", object@version)
-  }
+  objMaj <- package_version(object@version)$major
+  pkgMaj <- package_version(packageVersion("Seurat"))$major
 
   if (objMaj != pkgMaj) {
-          stop("The installed major version of Seurat is different from Seurat input object. You have to down- or upgrade your installed Seurat version. See the Seurat documentation.")
+          message("The installed major version of Seurat is different from Seurat input object. Running the UpdateSeuratObject() function now")
+          object <- UpdateSeuratObject(object)
   }
 
-  reducNames = reductions
+  message("Seurat object summary:")
+  print(object)
 
-  # compatibility layer for Seurat 2 vs 3
-  # see https://satijalab.org/seurat/essential_commands.html
-  if (inherits(x = object, what = 'seurat')) {
-      # Seurat v2 objects are called "seurat" (Paul Hoffman)
-      # -> Seurat 2 data access
-      idents <- object@ident # Idents() in Seurat3
-      meta <- object@meta.data
-      cellOrder <- object@cell.names
-      if (matrix.slot=="counts") {
-          counts <- object@raw.data
-      } else if (matrix.slot=="scale.data") {
-          counts <- object@scale.data
-      }
-      else if (matrix.slot=="data") {
-          counts <- object@data
-      } else {
-          error("matrix.slot can only be one of: counts, scale.data, data")
-      }
-      genes <- rownames(x = object@data)
-      dr <- object@dr
-  } else {
-    # Seurat 3 functions
-    idents <- Idents(object = object)
-    meta <- object[[]]
-    cellOrder <- colnames(x = object)
-    counts <- findMatrix(object = object, matrix.slot = matrix.slot)
-    if (dim(x = counts)[1] == 0) {
-      message(paste0("The Seurat data slot '", matrix.slot, "' contains no data. Trying default assay."))
-      defAssay <- DefaultAssay(object)
-      assay <- GetAssay(object, defAssay)
-      message(paste0("Default assay is ", defAssay))
-      counts <- findMatrix(assay, matrix.slot)
-      genes <- rownames(counts)
-      if (dim(x = counts)[1] == 0) {
-        stop(
-          "Could not find an expression matrix",
-          "Please select the correct slot where the matrix is stored, possible ",
-          "values are 'counts', 'scale.data' or 'data'. To select a slot, ",
-          "use the option 'matrix.slot' from R or the cbImportSeurat option -s from the command line."
-        )
-      }
-    }
-    else {
-      genes <- rownames(x = object)
-    }
-    dr <- object@reductions
-  }
+  # a vector with the slot names to export
+  slotNames <- unlist(strsplit(matrix.slot, ","))
+
+  # shortcuts to make the code below easier to read (originally this was also to isolate us from the Seurat2/3 issue
+  idents <- Idents(object = object)
+  meta <- object[[]]
+  cellOrder <- colnames(x = object)
+  slotMatrices <- findMatrices(object = object, slotNames = slotNames)
+  dr <- object@reductions
+  reducNames <- reductions
+
+  # check input arguments
   if (is.null(x = cluster.field)) {
     cluster.field = "Cluster"
   }
@@ -247,38 +262,11 @@ ExportToCellbrowser <- function(
   }
   enum.fields <- c()
 
-  # Export expression matrix
-  if (!skip.expr.matrix) {
-      too.big = ((((ncol(counts)/1000)*(nrow(counts)/1000))>2000) && is(counts, 'sparseMatrix'))
-      if (use.mtx || (too.big && (.Platform$OS.type=="windows"))) {
-            # we have to write the matrix to an mtx file
-            matrixPath <- file.path(dir, "matrix.mtx")
-            genesPath <- file.path(dir, "features.tsv")
-            barcodesPath <- file.path(dir, "barcodes.tsv")
-            message("Writing expression matrix to ", matrixPath)
-            writeMM(counts, matrixPath)
-            # easier to load if the genes file has at least two columns. Even though seurat objects
-            # don't have yet explicit geneIds/geneSyms data, we just duplicate whatever the matrix has now
-            write.table(as.data.frame(cbind(rownames(counts), rownames(counts))), file=genesPath, sep="\t", row.names=F, col.names=F, quote=F)
-            write(colnames(counts), file = barcodesPath)
-            message("Gzipping expression matrix")
-            gzip(matrixPath)
-            gzip(genesPath)
-            gzip(barcodesPath)
-      } else {
-          # we can write the matrix as a tsv file
-          gzPath <- file.path(dir, "exprMatrix.tsv.gz")
-          if (too.big) {
-              writeSparseTsvChunks(counts, gzPath);
-          } else {
-              mat = as.matrix(counts)
-              df <- as.data.frame(mat, check.names=FALSE)
-              df <- data.frame(gene=genes, df, check.names = FALSE)
-              z <- gzfile(gzPath, "w")
-              message("Writing expression matrix to ", gzPath)
-              write.table(x = df, sep="\t", file=z, quote = FALSE, row.names = FALSE)
-              close(con = z)
-          }
+  # save the matrices 
+  if (! skip.expr.matrix) {
+      for (prefix in names(slotMatrices)) {
+          mat <- slotMatrices[[prefix]]
+          saveMatrix(mat, dir, prefix, use.mtx)
       }
   }
 
@@ -363,7 +351,14 @@ ExportToCellbrowser <- function(
     if (length(levels(idents)) > 1) {
       markers.helper <- function(x) {
         partition <- markers[x,]
-        ord <- order(partition$p_val_adj < 0.05, -partition$avg_logFC)
+
+        # Seurat4 has changed the field name! grrrr...
+        if ("avg_log2FC" %in% colnames(markers))
+            avgs <- -partition$avg_log2FC
+        else
+            avgs <- -partition$avg_logFC
+
+        ord <- order(partition$p_val_adj < 0.05, avgs)
         res <- x[ord]
         naCount <- max(0, length(x) - markers.n)
         res <- c(res[1:markers.n], rep(NA, naCount))
@@ -397,17 +392,39 @@ ExportToCellbrowser <- function(
       file
     )
   }
-  matrixOutPath <- "exprMatrix.tsv.gz"
+
+  firstPrefix <- names(slotMatrices)[1]
+  if (length(slotMatrices)==1)
+      matSep = ""
+  else
+      matSep = "_"
+
+  # we assume that any slotname is possible. (in the wild, only 'counts' and 'scale.data' seem to occur, but we tolerate others)
+  matrixNames <- names(slotMatrices)
+  matrixLabels <- matrixNames
+  matrixLabels[matrixLabels=="counts"] <- "read counts"
+  matrixLabels[matrixLabels=="scale.data"] <- "scaled"
+  matrices.conf <- sprintf(" {'label':'%s','fileName':'%s_exprMatrix.tsv.gz'}", names(slotMatrices), names(slotMatrices))
+
+  if (length(slotMatrices)==1)
+     matrices.string <- ""
+  else
+     matrices.string <- paste0("matrices=[", paste(matrices.conf, collapse = ",\n"), "]" )
+
+  matrixOutPath <- sprintf("%s%sexprMatrix.tsv.gz", firstPrefix, matSep)
   if (use.mtx) {
-    matrixOutPath <- "matrix.mtx.gz"
+    matrixOutPath <- sprintf("%s%smatrix.mtx.gz", firstPrefix, matSep)
   }
-  config <- '
-# This is a bare-bones cellbrowser config file auto-generated from R.
+
+
+  config <- '# This is a bare-bones cellbrowser config file auto-generated by the command-line tool cbImportSeurat 
+# or directly from R with SeuratWrappers::ExportToCellbrowser().
 # Look at https://github.com/maximilianh/cellBrowser/blob/master/src/cbPyLib/cellbrowser/sampleConfig/cellbrowser.conf
 # for a full file that shows all possible options
 name="%s"
 shortLabel="%1$s"
 exprMatrix="%s"
+%s
 #tags = ["10x", "smartseq2"]
 meta="meta.tsv"
 # possible values: "gencode-human", "gencode-mouse", "symbol" or "auto"
@@ -418,28 +435,28 @@ clusterField="%s"
 labelField="%s"
 enumFields=%s
 %s
-coords=%s'
-  enum.string <- paste0(
-    "[",
-    paste(paste0('"', enum.fields, '"'), collapse = ", "),
-    "]"
-  )
-  coords.string <- paste0(
-    "[",
-    paste(embeddings.conf, collapse = ",\n"),
-    "]"
-  )
+coords=%s
+'
+
+  # the R code continues here. Some text editors are confused and don't realize that the multi-line string
+  # has ended.
+  enum.string <- paste0( "[", paste(paste0('"', enum.fields, '"'), collapse = ", "), "]" )
+
+  coords.string <- paste0( "[", paste(embeddings.conf, collapse = ",\n"), "]" )
+
   config <- sprintf(
     config,
     dataset.name,
     matrixOutPath,
+    matrices.string,
     cluster.field,
     cluster.field,
     enum.string,
     markers.string,
     coords.string
   )
-  confPath = file.path(dir, "cellbrowser.conf")
+
+  confPath <- file.path(dir, "cellbrowser.conf")
   message("Writing cellbrowser config to ", confPath)
   cat(config, file = confPath)
   message("Prepared cellbrowser directory ", dir)


### PR DESCRIPTION
- removing Seurat2 support and replace with UpdateSeuratObject() (discovered thanks to @matthewspeir, will save us countless hours of keeping our Seurat 2/3/4 conda environments updated if it works)
- adding support for Seurat 4 (Seurat4 renamed the field avg_logFC to avg_log2FC, which of course breaks every program using the Seurat marker output)
- allow exporting multiple matrices
- stop if on windows and matrix is too big, which is better than my previous approach
- creating one more function
- tested on pbmc_small from Seurat2, Seurat3, and Seurat4, yay!