### PR TITLE
Update scVIIntegration to take `StdAssay`/`SCTAssay` as input

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,6 +5,7 @@ Date: 2024-01-23
 Authors@R: c(
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),
   person(given = "Saket", family = "Choudhary", email = "schoudhary@nygenome.org", role = "ctb", comment = c(ORCID = "0000-0001-5202-7633")),
+  person(given = 'David', family = 'Collins', email = 'dcollins@nygenome.org', role = 'ctb', comment = c(ORCID = '0000-0001-9243-7821')),
   person(given = "Yuhan", family = "Hao", email = "yhao@nygenome.org", role = "ctb", comment = c(ORCID = "0000-0002-1810-0822")),
   person(given = "Austin", family = "Hartman", email = "ahartman@nygenome.org", role = "ctb", comment = c(ORCID = "0000-0001-7278-1852")),
   person(given = 'Paul', family = 'Hoffman', email = 'nygcSatijalab@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0002-7693-8957')),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratWrappers
 Title: Community-Provided Methods and Extensions for the Seurat Object
-Version: 0.3.3
-Date: 2024-01-19
+Version: 0.3.4
+Date: 2024-01-23
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,14 +3,14 @@ Title: Community-Provided Methods and Extensions for the Seurat Object
 Version: 0.3.4
 Date: 2024-01-23
 Authors@R: c(
-  person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),
-  person(given = 'Paul', family = 'Hoffman', email = 'nygcSatijalab@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0002-7693-8957')),
-  person(given = 'Tim', family = 'Stuart', email = 'tstuart@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0002-3044-0897')), 
+  person(given = "Saket", family = "Choudhary", email = "schoudhary@nygenome.org", role = "ctb", comment = c(ORCID = "0000-0001-5202-7633")),
   person(given = "Yuhan", family = "Hao", email = "yhao@nygenome.org", role = "ctb", comment = c(ORCID = "0000-0002-1810-0822")),
   person(given = "Austin", family = "Hartman", email = "ahartman@nygenome.org", role = "ctb", comment = c(ORCID = "0000-0001-7278-1852")),
+  person(given = 'Paul', family = 'Hoffman', email = 'nygcSatijalab@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0002-7693-8957')),
   person(given = "Gesmira", family = "Molla", email = 'gmolla@nygenome.org', role = 'ctb', comment = c(ORCID = '0000-0002-8628-5056')),
-  person(given = "Saket", family = "Choudhary", email = "schoudhary@nygenome.org", role = "ctb", comment = c(ORCID = "0000-0001-5202-7633"))
+  person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
+  person(given = 'Tim', family = 'Stuart', email = 'tstuart@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0002-3044-0897'))
   )
 Description: SeuratWrappers is a collection of community-provided methods and
     extensions for Seurat, curated by the Satija Lab at NYGC. These methods

--- a/R/scVI.R
+++ b/R/scVI.R
@@ -2,21 +2,27 @@
 #'
 NULL
 
-#' Run scVI in seurat5
-#' @param object An Assay containing merged data
-#' names should be cell identifiers and values their respective batch keys
+#' scVI Integration
+#' @param object A \code{StdAssay} or \code{STDAssay} instance containing
+#' merged data
 #' @param features Features to integrate
 #' @param layers Layers to integrate
 #' @param conda_env conda environment to run scVI
 #' @param new.reduction Name under which to store resulting DimReduc object
-#' @param ... Unused - currently just capturing parameters passed in from 
+#' @param ndims Dimensionality of the latent space
+#' @param nlayers Number of hidden layers used for encoder and decoder NNs
+#' @param gene_likelihood Distribution to use for modelling expression 
+#' data: {"zinb", "nb", "poisson"}
+#' @param max_epochs Number of passes through the dataset taken while
+#' training the model
+#' @param ... Unused - currently just capturing parameters passed in from
 #' \code{Seurat::IntegrateLayers} intended for other integration methods
 #'
 #' @export
 #'
 #' @note This function requires the
-#' \href{https://docs.scvi-tools.org/en/stable/installation.html}{\pkg{scvi-tools}} package
-#' to be installed
+#' \href{https://docs.scvi-tools.org/en/stable/installation.html}{\pkg{scvi-tools}}
+#' package to be installed
 #'
 #' @examples
 #' \dontrun{
@@ -29,19 +35,27 @@ NULL
 #' obj <- RunPCA(obj)
 #'
 #' # After preprocessing, we integrate layers, specifying a conda environment
-#' obj <- IntegrateLayers(object = obj, method = scVIIntegration, new.reduction = 'integrated.scvi',
-#'                        conda_env = '../miniconda3/envs/scvi-env', verbose = FALSE)
-#' }
+#' obj <- IntegrateLayers(
+#'   object = obj,
+#'   method = scVIIntegration,
+#'   new.reduction = "integrated.scvi",
+#'   conda_env = "../miniconda3/envs/scvi-env",
+#'   verbose = FALSE
+#' )
 #'
 #' # Alternatively, we can integrate SCTransformed data
 #' obj <- SCTransform(object = obj)
-#' obj <- IntegrateLayers(object = obj, method = scVIIntegration,
-#'           orig.reduction = "pca", new.reduction = 'integrated.scvi',
-#'            assay = "SCT", conda_env = '../miniconda3/envs/scvi-env', verbose = FALSE)
+#' obj <- IntegrateLayers(
+#'   object = obj, method = scVIIntegration,
+#'   orig.reduction = "pca", new.reduction = "integrated.scvi",
+#'   assay = "SCT", conda_env = "../miniconda3/envs/scvi-env", verbose = FALSE
+#' )
+#' }
 #'
 #' @seealso \href{https://docs.scvi-tools.org/en/stable/tutorials/notebooks/scvi_in_R.html}{scVI}
 #'
-#' @return A Seurat object with embeddings and loadings
+#' @return A single-element named list \code{DimReduc} elements containing
+#' the integrated data
 
 scVIIntegration <- function(
     object,

--- a/man/SeuratWrappers-package.Rd
+++ b/man/SeuratWrappers-package.Rd
@@ -13,17 +13,18 @@ SeuratWrappers is a collection of community-provided methods and extensions for 
 
 Authors:
 \itemize{
-  \item Rahul Satija \email{rsatija@nygenome.org} (\href{https://orcid.org/0000-0001-9448-8833}{ORCID})
   \item Andrew Butler \email{abutler@nygenome.org} (\href{https://orcid.org/0000-0003-3608-0463}{ORCID})
+  \item Rahul Satija \email{rsatija@nygenome.org} (\href{https://orcid.org/0000-0001-9448-8833}{ORCID})
   \item Tim Stuart \email{tstuart@nygenome.org} (\href{https://orcid.org/0000-0002-3044-0897}{ORCID})
 }
 
 Other contributors:
 \itemize{
+  \item Saket Choudhary \email{schoudhary@nygenome.org} (\href{https://orcid.org/0000-0001-5202-7633}{ORCID}) [contributor]
+  \item David Collins \email{dcollins@nygenome.org} (\href{https://orcid.org/0000-0001-9243-7821}{ORCID}) [contributor]
   \item Yuhan Hao \email{yhao@nygenome.org} (\href{https://orcid.org/0000-0002-1810-0822}{ORCID}) [contributor]
   \item Austin Hartman \email{ahartman@nygenome.org} (\href{https://orcid.org/0000-0001-7278-1852}{ORCID}) [contributor]
   \item Gesmira Molla \email{gmolla@nygenome.org} (\href{https://orcid.org/0000-0002-8628-5056}{ORCID}) [contributor]
-  \item Saket Choudhary \email{schoudhary@nygenome.org} (\href{https://orcid.org/0000-0001-5202-7633}{ORCID}) [contributor]
 }
 
 }

--- a/man/scVIIntegration.Rd
+++ b/man/scVIIntegration.Rd
@@ -2,11 +2,10 @@
 % Please edit documentation in R/scVI.R
 \name{scVIIntegration}
 \alias{scVIIntegration}
-\title{Run scVI in seurat5}
+\title{scVI Integration}
 \usage{
 scVIIntegration(
   object,
-  groups = NULL,
   features = NULL,
   layers = "counts",
   conda_env = NULL,
@@ -19,30 +18,41 @@ scVIIntegration(
 )
 }
 \arguments{
-\item{object}{A merged Seurat object}
+\item{object}{A \code{StdAssay} or \code{STDAssay} instance containing
+merged data}
 
-\item{groups}{Name of the metadata column to be used as the 'batch_key'}
+\item{features}{Features to integrate}
 
-\item{features}{features to use}
-
-\item{layers}{Layers to use}
+\item{layers}{Layers to integrate}
 
 \item{conda_env}{conda environment to run scVI}
 
-\item{new.reduction}{Name to store resulting DimReduc object as}
+\item{new.reduction}{Name under which to store resulting DimReduc object}
 
-\item{...}{Arguments passed to other methods}
+\item{ndims}{Dimensionality of the latent space}
+
+\item{nlayers}{Number of hidden layers used for encoder and decoder NNs}
+
+\item{gene_likelihood}{Distribution to use for modelling expression 
+data: {"zinb", "nb", "poisson"}}
+
+\item{max_epochs}{Number of passes through the dataset taken while
+training the model}
+
+\item{...}{Unused - currently just capturing parameters passed in from
+\code{Seurat::IntegrateLayers} intended for other integration methods}
 }
 \value{
-A Seurat object with embeddings and loadings
+A single-element named list \code{DimReduc} elements containing
+the integrated data
 }
 \description{
-Run scVI in seurat5
+scVI Integration
 }
 \note{
 This function requires the
-\href{https://docs.scvi-tools.org/en/stable/installation.html}{\pkg{scvi-tools}} package
-to be installed
+\href{https://docs.scvi-tools.org/en/stable/installation.html}{\pkg{scvi-tools}}
+package to be installed
 }
 \examples{
 \dontrun{
@@ -55,15 +65,22 @@ obj <- ScaleData(obj)
 obj <- RunPCA(obj)
 
 # After preprocessing, we integrate layers, specifying a conda environment
-obj <- IntegrateLayers(object = obj, method = scVIIntegration, new.reduction = 'integrated.scvi',
-                       conda_env = '../miniconda3/envs/scvi-env', verbose = FALSE)
-}
+obj <- IntegrateLayers(
+  object = obj,
+  method = scVIIntegration,
+  new.reduction = "integrated.scvi",
+  conda_env = "../miniconda3/envs/scvi-env",
+  verbose = FALSE
+)
 
 # Alternatively, we can integrate SCTransformed data
 obj <- SCTransform(object = obj)
-obj <- IntegrateLayers(object = obj, method = scVIIntegration,
-          orig.reduction = "pca", new.reduction = 'integrated.scvi',
-           assay = "SCT", conda_env = '../miniconda3/envs/scvi-env', verbose = FALSE)
+obj <- IntegrateLayers(
+  object = obj, method = scVIIntegration,
+  orig.reduction = "pca", new.reduction = "integrated.scvi",
+  assay = "SCT", conda_env = "../miniconda3/envs/scvi-env", verbose = FALSE
+)
+}
 
 }
 \seealso{


### PR DESCRIPTION
Follow up to #179 - unfortunately, the complimentary fix to https://github.com/satijalab/seurat-wrappers/pull/179 (https://github.com/satijalab/seurat-private/pull/894) caused `IntegrateLayers` to break if `SeuratWrappers` was not installed. 

This PR resolves the problem by bringing `scVIIntegration` into better sync with the methods provided natively in `Seurat` and operating on `Assay`s as opposed to `Seurat` instances. 

Since I was in the neighborhood I've done a bit of tidying up but in the process reformatted the code in a kinda opinionated way (I'm running `styler`) - keen to hear what folks think!

Once https://github.com/satijalab/seurat-private/pull/895 is merged `SeuratWrappers` will be compatible with prod and develop versions of `Seurat` and the following script should run as before:

```R
library(rlang)
library(Seurat)
library(SeuratData)
library(SeuratWrappers)

InstallData("ifnb")
ifnb <- LoadData("ifnb")

# split the RNA assay into layers for control and stimulated cells, respectively
ifnb[["RNA"]] <- split(ifnb[["RNA"]], f = ifnb$stim)

# run standard anlaysis workflow
ifnb <- NormalizeData(ifnb)
ifnb <- FindVariableFeatures(ifnb)
ifnb <- ScaleData(ifnb)
ifnb <- RunPCA(ifnb)

# integrate using scVI
ifnb <- IntegrateLayers(
  object = ifnb,
  method = scVIIntegration,
  orig.reduction = "pca",
  new.reduction = "integrated.scvi",
  conda_env = "path/to/conda/env",
  verbose = TRUE,
  # set low to speed things up
  max_epochs = 10,
)
```

Closes:
- https://github.com/satijalab/project-management/issues/21

