### PR TITLE
Fixed bug with running scVI integration over SCTransformed data

### DIFF
--- a/R/scVI.R
+++ b/R/scVI.R
@@ -5,6 +5,7 @@ NULL
 #' scVI Integration
 #' @param object A \code{StdAssay} or \code{STDAssay} instance containing
 #' merged data
+#' @param assay Assay name passed, to be logged in the DimRedc object
 #' @param features Features to integrate
 #' @param layers Layers to integrate
 #' @param conda_env conda environment to run scVI
@@ -58,6 +59,7 @@ NULL
 #' the integrated data
 scVIIntegration <- function(
     object,
+    assay = NULL,
     features = NULL,
     layers = "counts",
     conda_env = NULL,
@@ -67,7 +69,7 @@ scVIIntegration <- function(
     gene_likelihood = "nb",
     max_epochs = NULL,
     ...) {
-  
+
   # import python methods from specified conda env
   reticulate::use_condaenv(conda_env, required = TRUE)
   sc <- reticulate::import("scanpy", convert = FALSE)
@@ -128,7 +130,8 @@ scVIIntegration <- function(
   suppressWarnings(
     latent.dr <- CreateDimReducObject(
       embeddings = latent, 
-      key = new.reduction
+      key = new.reduction,
+      assay = assay
     )
   )
   # to make it easier to add the reduction into a `Seurat` instance

--- a/R/scVI.R
+++ b/R/scVI.R
@@ -86,11 +86,14 @@ scVIIntegration <- function(
 
   # build a meta.data-style data.frame indicating the batch for each cell
   batches <- .FindBatches(object, layers = layers)
-  # scVI expects a single counts matrix so we'll join our layers together
-  # it also expects the raw counts matrix
-  # TODO: avoid hardcoding this - users can rename their layers arbitrarily
-  # so there's no gauruntee that the usual naming conventions will be followed
-  object <- JoinLayers(object = object, layers = "counts")
+  
+  if (inherits(x = object, what = 'StdAssay')) {
+    # scVI expects a single counts matrix so we'll join our layers together
+    # it also expects the raw counts matrix
+    # TODO: avoid hardcoding this - users can rename their layers arbitrarily
+    # so there's no gauruntee that the usual naming conventions will be followed
+    object <- JoinLayers(object = object, layers = "counts")
+  }
   # setup an `AnnData` python instance
   adata <- sc$AnnData(
     X = scipy$sparse$csr_matrix(


### PR DESCRIPTION
As described at the bottom of [this issue](https://github.com/satijalab/seurat/issues/7164) , when running `IntegrateLaters` over an `SCT` assay with the `scVIIntegration` method, we get the following error:

```
Error in UseMethod(generic = "JoinLayers", object = object) : 
  no applicable method for 'JoinLayers' applied to an object of class "c('SCTAssay', 'Assay', 'KeyMixin')"
```

This error happens when calling `JoinLayers` (line 93). The purpose of this line is to join the different (count) layers so to create a single counts matrix to pass to AnnData (line 98, calling `LayerData`). While the call to `JoinLayers` is indeed needed for a standard assay (and thus `scVIIntegration` works over RNA assay), it is not needed for an `SCTAssay` as calling `LayerData` with such an assay pulls the information from all nested SCTModels. The proposed solution is therefore to call `JoinLayers` only or standard assays:

```
if (inherits(x = object, what = 'StdAssay')) {
  object <- JoinLayers(object = object, layers = "counts")
}
```


<br>
One additional change regards the downstream use of the scVI integrated reduction object. When calling `FindClusters` over an `SCTransform` + `scVIIntegration` + `FindNeighbors` object, it states that there is no graph with the passed name (i.e. by default `"SCT_snn"`). That is because the newly created dimensionality reduction object has an `assay.used` of `"RNA"`. As such the saved graph name is then `"RNA_snn"`, while `FindClusters` is looking for `"SCT_snn"`. To fix that I've:

- Added `assay = NULL` as an argument of the function (which is passed from `IntegrateLayers` as SCT (for SCT being the specified assay or the default one)
- Added `assay = assay` in the `CreateDimReducObject`.

----

Code for testing:

```
library(Seurat)
library(SeuratWrappers)
library(dplyr)

# Testing that scVIIntegration over RNA assay still works
obj <- LoadSeuratRds("seurat.object.rds") # "Fresh" object with only a count matrix
obj[["RNA"]] <- split(obj[["RNA"]], obj$orig.ident)
obj <- NormalizeData(obj, verbose=F) %>% FindVariableFeatures(verbose=F) %>% ScaleData(verbose=F) %>% RunPCA(verbose = F)
obj <- IntegrateLayers(
  object = obj,
  method = scVIIntegration,
  conda_env = "conda/env/path",
  verbose = TRUE
)

# Testing that fix actually fixed the problem
obj <- LoadSeuratRds("seurat.object.rds") # "Fresh" object with only a count matrix
obj[["RNA"]] <- split(obj[["RNA"]], obj$orig.ident)
obj <- SCTransform(obj, verbose=F) %>% RunPCA(verbose = F)
obj <- IntegrateLayers(
  object = obj,
  method = scVIIntegration,
  new.reduction = "integrated.scVI",
  conda_env = "conda/env/path",
  verbose = TRUE
)

# Verify that downstream clustering over integrated embedding works
obj <- FindNeighbors(obj, reduction = "integrated.scVI", dims = 1:30, verbose=F) %>%
    FindClusters(resolution = 3, verbose=F) %>%
    RunUMAP(reduction = "integrated.scVI", dims = 1:30, reduction.name = "umap.scVI", verbose=F)
```

