### PR TITLE
fix "undefined columns selected" if column renamed

### DIFF
--- a/R/miqc.R
+++ b/R/miqc.R
@@ -117,13 +117,13 @@ RunMiQC <- function(
     else if (backup.option == "percentile") {
       message("defaulting to backup.percentile for filtering")
       compromised_probability <- 0
-      raw_values <- my_data[,percent.mt]
+      raw_values <- my_data[,"percent.mt"]
       percentile_cutoff <- quantile(raw_values, probs = backup.percentile)
       cells_to_keep <- ifelse(raw_values <= percentile_cutoff, "keep", "discard")}
     else if (backup.option == "percent"){
       message("defaulting to backup.percent for filtering")
       compromised_probability <- 0
-      raw_values <- my_data[,percent.mt]
+      raw_values <- my_data[,"percent.mt"]
       cells_to_keep <- ifelse(raw_values <= backup.percent, "keep", "discard")}
     else {
       stop("backup.option must be one of \"percentile\", \"percent\", \"halt\", or \"pass\"")


### PR DESCRIPTION
Users can choose their own `percent.mt` column name to fetch from their data, and the resulting column is subsequently renamed in as `"percent.mt"` in `my_data`:
https://github.com/satijalab/seurat-wrappers/blob/8d46d6c47c089e193fe5c02a8c23970715918aa9/R/miqc.R#L57-L58


However, when subsetting on lines 120 & 126 (if the else if conditions of lines 117-127 are met), we get "undefined columns selected" errors if the user passed in anything other than the default to `percent.mt` – because we're subsetting using the value stored in the `percent.mt` variable:
https://github.com/satijalab/seurat-wrappers/blob/8d46d6c47c089e193fe5c02a8c23970715918aa9/R/miqc.R#L117-L127


Solutions include either reassigning `percent.mt <- "percent.mt"` after line 58, or subsetting on line 120 & 126 with the character value `"percent.mt"` that we've forced the column to be named as. I chose the latter of these two options.

Let me know if you have any comments, and feel free to edit if necessary. Thanks!