### PR TITLE
FindAllMarkers in CIPR docs

### DIFF
--- a/docs/cipr.Rmd
+++ b/docs/cipr.Rmd
@@ -132,7 +132,7 @@ pbmc$unnamed_clusters <- Idents(pbmc)
 
 __This is the step where we generate the input for CIPR's log fold change (logFC) comparison methods.__
 
-```{r, echo=F, results="hide"}
+```{r, results="hide"}
 allmarkers <- FindAllMarkers(pbmc)
 ```
 

--- a/docs/cipr.md
+++ b/docs/cipr.md
@@ -125,6 +125,10 @@ pbmc$unnamed_clusters <- Idents(pbmc)
 **This is the step where we generate the input for CIPR’s log fold
 change (logFC) comparison methods.**
 
+``` r
+allmarkers <- FindAllMarkers(pbmc)
+```
+
 ## Calculate average gene expression per cluster
 
 **This is the step where we generate the input for CIPR’s all-genes


### PR DESCRIPTION
I changed the Rmd file to show the FIndAllMarkers line that was set to echo=FALSE before.
Changed rendered files.