### PR TITLE
allow regress out covariates for scVI intergration 

### DIFF
--- a/R/scVI.R
+++ b/R/scVI.R
@@ -64,6 +64,7 @@ scVIIntegration <- function(
     new.reduction = "integrated.dr",
     ndims = 30,
     nlayers = 2,
+    meta.data.df = NULL,
     categorical.vars.to.regress = NULL,
     continuous.vars.to.regress = NULL,
     gene_likelihood = "nb",
@@ -92,16 +93,21 @@ scVIIntegration <- function(
   if (any('batch' %in% c(categorical.vars.to.regress, continuous.vars.to.regress))) {
     stop('Not use "batch" string in vars.to.regress, change it to another string!')
   }
-
+  # check meta.data data.frame
+  if (any(!is.null(categorical.vars.to.regress), !is.null(continuous.vars.to.regress))) {
+    if (is.null(meta.data.df)) {
+      stop("meta.data.df can be null if any categorical.vars.to.regress or continuous.vars.to.regress is not null!")
+    }
+  }
   # add covariates to batches
   if (!is.null(categorical.vars.to.regress)) {
-    if (!all(categorical.vars.to.regress %in% colnames(object@meta.data))) {
+    if (!all(categorical.vars.to.regress %in% colnames(meta.data.df))) {
       stop("Not all categorical.vars.to.regress existed!")
     }
-    if(!all(sapply(object@meta.data[,categorical.vars.to.regress], is.factor))){
+    if(!all(sapply(meta.data.df[,categorical.vars.to.regress], is.factor))){
       stop("All categorical.vars.to.regress should be factor!")
     }
-    batches <- cbind(batches, object@meta.data[,categorical.vars.to.regress])
+    batches <- cbind(batches, meta.data.df[,categorical.vars.to.regress])
   }
 
   # scVI expects a single counts matrix so we'll join our layers together

--- a/R/scVI.R
+++ b/R/scVI.R
@@ -96,7 +96,7 @@ scVIIntegration <- function(
   # check meta.data data.frame
   if (any(!is.null(categorical.vars.to.regress), !is.null(continuous.vars.to.regress))) {
     if (is.null(meta.data.df)) {
-      stop("meta.data.df can be null if any categorical.vars.to.regress or continuous.vars.to.regress is not null!")
+      stop("meta.data.df can not be null if any categorical.vars.to.regress or continuous.vars.to.regress is not null!")
     }
   }
   # add covariates to batches

--- a/R/scVI.R
+++ b/R/scVI.R
@@ -139,7 +139,7 @@ scVIIntegration <- function(
   }else if (!is.null(categorical.vars.to.regress) & is.null(continuous.vars.to.regress)) {
     scvi$model$SCVI$setup_anndata(adata, categorical_covariate_keys = c('batch', categorical.vars.to.regress))
   }else if (is.null(categorical.vars.to.regress) & !is.null(continuous.vars.to.regress)) {
-    scvi$model$SCVI$setup_anndata(adata, categorical.vars.to.regress = "batch",
+    scvi$model$SCVI$setup_anndata(adata, batch_key = "batch",
                                   continuous_covariate_keys = continuous.vars.to.regress)
   }else{
     scvi$model$SCVI$setup_anndata(adata, categorical_covariate_keys = c('batch',categorical.vars.to.regress),

--- a/R/scVI.R
+++ b/R/scVI.R
@@ -107,9 +107,18 @@ scVIIntegration <- function(
     if(!all(sapply(meta.data.df[,categorical.vars.to.regress], is.factor))){
       stop("All categorical.vars.to.regress should be factor!")
     }
-    batches <- cbind(batches, meta.data.df[,categorical.vars.to.regress])
+    batches <- cbind(batches, meta.data.df[,categorical.vars.to.regress, drop = FALSE])
   }
 
+  if (!is.null(continuous.vars.to.regress)) {
+    if (!all(continuous.vars.to.regress %in% colnames(meta.data.df))) {
+      stop("Not all continuous.vars.to.regress existed!")
+    }
+    if(!all(sapply(meta.data.df[,continuous.vars.to.regress], is.numeric))){
+      stop("All continuous.vars.to.regress should be numeric!")
+    }
+    batches <- cbind(batches, meta.data.df[,continuous.vars.to.regress, drop = FALSE])
+  }
   # scVI expects a single counts matrix so we'll join our layers together
   # it also expects the raw counts matrix
   # TODO: avoid hardcoding this - users can rename their layers arbitrarily
@@ -128,11 +137,12 @@ scVIIntegration <- function(
   if (all(c(is.null(categorical.vars.to.regress), is.null(continuous.vars.to.regress)))) {
     scvi$model$SCVI$setup_anndata(adata, batch_key = "batch")
   }else if (!is.null(categorical.vars.to.regress) & is.null(continuous.vars.to.regress)) {
-    scvi$model$SCVI$setup_anndata(adata, batch_key = "batch", categorical_covariate_keys = categorical.vars.to.regress)
+    scvi$model$SCVI$setup_anndata(adata, categorical_covariate_keys = c('batch', categorical.vars.to.regress))
   }else if (is.null(categorical.vars.to.regress) & !is.null(continuous.vars.to.regress)) {
-    scvi$model$SCVI$setup_anndata(adata, batch_key = "batch", continuous_covariate_keys = continuous.vars.to.regress)
+    scvi$model$SCVI$setup_anndata(adata, categorical.vars.to.regress = "batch",
+                                  continuous_covariate_keys = continuous.vars.to.regress)
   }else{
-    scvi$model$SCVI$setup_anndata(adata, batch_key = "batch", categorical_covariate_keys = categorical.vars.to.regress,
+    scvi$model$SCVI$setup_anndata(adata, categorical_covariate_keys = c('batch',categorical.vars.to.regress),
                                   continuous_covariate_keys = continuous.vars.to.regress)
   }
 

--- a/R/scVI.R
+++ b/R/scVI.R
@@ -133,8 +133,6 @@ scVIIntegration <- function(
     obs = batches,
     var = object[[]][features, ]
   )
-  # in case of error caused by reticulate for trans length 1 vector
-  continuous.vars.to.regress <- ifelse(length(continuous.vars.to.regress) == 1, list(continuous.vars.to.regress), continuous.vars.to.regress)
 
   # setup `anndata`
   if (all(c(is.null(categorical.vars.to.regress), is.null(continuous.vars.to.regress)))) {
@@ -142,10 +140,13 @@ scVIIntegration <- function(
   }else if (!is.null(categorical.vars.to.regress) & is.null(continuous.vars.to.regress)) {
     scvi$model$SCVI$setup_anndata(adata, categorical_covariate_keys = c('batch', categorical.vars.to.regress))
   }else if (is.null(categorical.vars.to.regress) & !is.null(continuous.vars.to.regress)) {
-
+    # in case of error caused by reticulate for trans length 1 vector
+    continuous.vars.to.regress <- ifelse(length(continuous.vars.to.regress) == 1, list(continuous.vars.to.regress), continuous.vars.to.regress)
     scvi$model$SCVI$setup_anndata(adata, batch_key = "batch",
                                   continuous_covariate_keys = continuous.vars.to.regress)
   }else{
+    # in case of error caused by reticulate for trans length 1 vector
+    continuous.vars.to.regress <- ifelse(length(continuous.vars.to.regress) == 1, list(continuous.vars.to.regress), continuous.vars.to.regress)
     scvi$model$SCVI$setup_anndata(adata, categorical_covariate_keys = c('batch',categorical.vars.to.regress),
                                   continuous_covariate_keys = continuous.vars.to.regress)
   }

--- a/R/scVI.R
+++ b/R/scVI.R
@@ -133,12 +133,16 @@ scVIIntegration <- function(
     obs = batches,
     var = object[[]][features, ]
   )
+  # in case of error caused by reticulate for trans length 1 vector
+  continuous.vars.to.regress <- ifelse(length(continuous.vars.to.regress) == 1, list(continuous.vars.to.regress), continuous.vars.to.regress)
+
   # setup `anndata`
   if (all(c(is.null(categorical.vars.to.regress), is.null(continuous.vars.to.regress)))) {
     scvi$model$SCVI$setup_anndata(adata, batch_key = "batch")
   }else if (!is.null(categorical.vars.to.regress) & is.null(continuous.vars.to.regress)) {
     scvi$model$SCVI$setup_anndata(adata, categorical_covariate_keys = c('batch', categorical.vars.to.regress))
   }else if (is.null(categorical.vars.to.regress) & !is.null(continuous.vars.to.regress)) {
+
     scvi$model$SCVI$setup_anndata(adata, batch_key = "batch",
                                   continuous_covariate_keys = continuous.vars.to.regress)
   }else{


### PR DESCRIPTION
add 3 new parameters.
1. meta.data.df: the meta.data from seurat object, default NULL, only works if any categorical.vars.to.regress or continuous.vars.to.regress is not NULL.
2. categorical.vars.to.regress: the covariates from meta.data of seurat objec, columns should be factor type. default NULL.
3.  continuous.vars.to.regress: the covariates from meta.data of seurat objec, columns should be numeric type. default NULL.
if you do not want to regress out any covariates, just leave all these 3 parameters default.