### PR TITLE
Update banksy.R - SeuratObject slot argument deprecation

### DIFF
--- a/R/banksy.R
+++ b/R/banksy.R
@@ -121,7 +121,7 @@ RunBanksy <- function(object, lambda, assay='RNA', slot='data', use_agf=FALSE,
     if (verbose) message('Setting default assay to ', assay_name)
     object[[assay_name]] <- banksy_assay
     DefaultAssay(object) <- assay_name
-    object <- SetAssayData(object, slot = 'scale.data', new.data = data_scaled,
+    object <- SetAssayData(object, layer = 'scale.data', new.data = data_scaled,
                            assay = assay_name)
 
     # Log commands
@@ -134,7 +134,7 @@ RunBanksy <- function(object, lambda, assay='RNA', slot='data', use_agf=FALSE,
 get_data <- function(object, assay, slot, features, verbose) {
     # Fetch data from Seurat
     if (verbose) message('Fetching data from slot ', slot,' from assay ', assay)
-    data_own <- Seurat::GetAssayData(object = object, assay = assay, slot = slot)
+    data_own <- Seurat::GetAssayData(object = object, assay = assay, layer = slot)
     # Feature subset
     if (features[1] != 'all') {
         if (verbose) message('Subsetting by features')


### PR DESCRIPTION
SeuratObject deprecated "slot" arguement in GetAssayData and SetAssayData. Since a recent version of SeuratObject, using the slot argument will result in an error. This commit fixes that.
In order to preserve compatibility with older scripts involving runbanksy, I have not changed the slot argument in runbanksy itself, this commit simply changes the GetAssayData and SetAssayData calls used within runbanksy. The changes are tested to be working with SeuratObject 5.3.0.