### PR TITLE
Update GetAssayData call in RunALRA.Seurat to use layer param

### DIFF
--- a/R/alra.R
+++ b/R/alra.R
@@ -200,7 +200,7 @@ RunALRA.Seurat <- function(
     k <- alra.previous[["k"]]
     message("Using previously computed value of k")
   }
-  data.used <- GetAssayData(object = object, assay = assay, slot = slot)[genes.use,]
+  data.used <- GetAssayData(object = object, assay = assay, layer = slot)[genes.use,]
   # Choose k with heuristics if k is not given
   if (is.null(x = k)) {
     # set K based on data dimension


### PR DESCRIPTION
Fixes #225.

The `slot` parameter of `GetAssayData` is defunct as of SeuratObject v5.3.0. 

A quick one-line fix solves the error in `RunALRA` by using the `layer` parameter instead of `slot` in the call to `GetAssayData` in `RunALRA.Seurat`.